### PR TITLE
Custom input node & change in data model

### DIFF
--- a/src/cache/mutations.js
+++ b/src/cache/mutations.js
@@ -63,7 +63,7 @@ export const CREATE_GRAPH = gql`
 //mutations for vertices
 
 export const CREATE_VERTEX = gql`
-  mutation($data: String!, $x: Int, $y: Int, $graphId: ID!) {
+  mutation($data: Data!, $x: Int, $y: Int, $graphId: ID!) {
     createVertex(data: $data, x: $x, y: $y, graphId: $graphId) {
       vertex {
         id
@@ -128,5 +128,13 @@ export const DELETE_EDGE = gql`
       success
       message
     }
+  }
+`;
+
+//local mutations
+
+export const UPDATE_VERTEX_LABEL = gql`
+  mutation($id: Int!, $newLabel: String!) {
+    updateVertexLabel(id: $id, newLabel: $newLabel) @client
   }
 `;

--- a/src/cache/queries.js
+++ b/src/cache/queries.js
@@ -84,6 +84,7 @@ export const GET_GRAPH = gql`
       vertices {
         id
         data
+        type
         x
         y
         targets {

--- a/src/cache/queries.js
+++ b/src/cache/queries.js
@@ -83,13 +83,20 @@ export const GET_GRAPH = gql`
     graph(id: $id) {
       vertices {
         id
-        data
         type
-        x
-        y
-        targets {
-          id
+        data {
+          label
         }
+        position {
+          x
+          y
+        }
+      }
+      edges {
+        id
+        source
+        target
+        animated
       }
     }
   }

--- a/src/cache/resolvers.js
+++ b/src/cache/resolvers.js
@@ -1,1 +1,30 @@
-export const resolvers = {};
+import gql from "graphql-tag";
+
+export const resolvers = {
+  Mutation: {
+    updateVertexLabel: (
+      _root,
+      { id: vertexId, newLabel },
+      { cache, getCacheKey }
+    ) => {
+      const id = getCacheKey({ __typename: "Vertex", id: vertexId });
+      const fragment = gql`
+        fragment label on Vertex {
+          data {
+            label
+          }
+        }
+      `;
+      const res = cache.readFragment({ fragment, id });
+      const data = {
+        __typename: "Vertex",
+        data: { __typename: "Data", label: newLabel },
+      };
+      cache.writeData({
+        id,
+        data,
+      });
+      return data;
+    },
+  },
+};

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -17,27 +17,6 @@ import { parseVertices } from "../utils";
 //   { id: "e1-2", source: "1", target: "2", animated: true },
 // ];
 
-// const elementsTypes = [
-//   {
-//     id: "1",
-//     type: "input",
-//     data: { label: "Input node" },
-//     position: { x: 100, y: 5 },
-//   },
-//   {
-//     id: "2",
-//     type: "default",
-//     data: { label: "Default node" },
-//     position: { x: 100, y: 100 },
-//   },
-//   {
-//     id: "3",
-//     type: "output",
-//     data: { label: "Output node" },
-//     position: { x: 100, y: 200 },
-//   },
-// ];
-
 const graphStyles = { width: "100%", height: "93vh" };
 
 const initialState = {
@@ -53,16 +32,6 @@ export default function Map(props) {
   const [newNodeCoord, setNewNodeCoord] = useState({ x: null, y: null });
 
   const elements = [...props.graphData.vertices, ...props.graphData.edges];
-
-  //pass onChange function...onChange, find the corresponding vertex, set its label to event value
-  //onChange thunk
-
-  /* do local state management entirely with cache;
-  use query to query vertices
-  -> manipulation of vertices can be done when using query within onChange
-  -> Will the elements be automatically updated? In other words, are changes broadcasted from Mapcreator component to Map component?
-    - if yes: good
-    - if no: perhaps you want to change the business logic and situate the GET_GRAPH query within Map component */
 
   /* handlers for context menu */
   const handleClickMenu = (event) => {

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -11,11 +11,11 @@ import inputNode from "./inputNode";
 import { showMessage } from "../utils/appState";
 import { parseVertices } from "../utils";
 
-const elements = [
-  { id: "1", data: { label: "Node 1" }, position: { x: 250, y: 5 } },
-  { id: "2", data: { label: "Node 2" }, position: { x: 100, y: 100 } },
-  { id: "e1-2", source: "1", target: "2", animated: true },
-];
+// const elements = [
+//   { id: "1", data: { label: "Node 1" }, position: { x: 250, y: 5 } },
+//   { id: "2", data: { label: "Node 2" }, position: { x: 100, y: 100 } },
+//   { id: "e1-2", source: "1", target: "2", animated: true },
+// ];
 
 // const elementsTypes = [
 //   {
@@ -51,6 +51,8 @@ export default function Map(props) {
   const [stateCoord, setStateCoord] = useState(initialState);
   const [newNodeData, setNewNodeData] = useState("");
   const [newNodeCoord, setNewNodeCoord] = useState({ x: null, y: null });
+
+  const elements = [...props.graphData.vertices, ...props.graphData.edges];
 
   //pass onChange function...onChange, find the corresponding vertex, set its label to event value
   //onChange thunk

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -1,11 +1,18 @@
 import React, { useState, useEffect } from "react";
-import ReactFlow, { Background, Controls } from "react-flow-renderer";
+import { useApolloClient } from "react-apollo";
+import ReactFlow, { Background, Controls, isEdge } from "react-flow-renderer";
+
 import Menu from "@material-ui/core/Menu";
 import MenuItem from "@material-ui/core/MenuItem";
 import Typography from "@material-ui/core/Typography";
-import { showMessage } from "../utils/appState";
-import { useApolloClient } from "react-apollo";
+
 import DialogForm from "../components/DialogForm";
+import { showMessage } from "../utils/appState";
+
+const CustomNodeFlow = () => {
+  const [elements, setElements] = useState([]);
+
+
 
 // const elements = [
 //   { id: "1", data: { label: "Node 1" }, position: { x: 250, y: 5 } },
@@ -36,8 +43,6 @@ import DialogForm from "../components/DialogForm";
 
 const graphStyles = { width: "100%", height: "93vh" };
 
-// const BasicGraph = () => <ReactFlow elements={elements} style={graphStyles} />;
-
 const initialState = {
   mouseX: null,
   mouseY: null,
@@ -50,10 +55,10 @@ export default function Map(props) {
   const [newNodeData, setNewNodeData] = useState("");
   const [newNodeCoord, setNewNodeCoord] = useState({ x: null, y: null });
 
-//   useEffect(() => {
-//     if (newNodeData !== "") {
-//     }
-//   }, [newNodeData, newNodeData, props.cre]);
+  //   useEffect(() => {
+  //     if (newNodeData !== "") {
+  //     }
+  //   }, [newNodeData, newNodeData, props.cre]);
 
   /* handlers for context menu */
   const handleClickMenu = (event) => {

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -7,14 +7,15 @@ import MenuItem from "@material-ui/core/MenuItem";
 import Typography from "@material-ui/core/Typography";
 
 import DialogForm from "../components/DialogForm";
+import inputNode from "./inputNode";
 import { showMessage } from "../utils/appState";
 import { parseVertices } from "../utils";
 
-// const elements = [
-//   { id: "1", data: { label: "Node 1" }, position: { x: 250, y: 5 } },
-//   { id: "2", data: { label: "Node 2" }, position: { x: 100, y: 100 } },
-//   { id: "e1-2", source: "1", target: "2", animated: true },
-// ];
+const elements = [
+  { id: "1", data: { label: "Node 1" }, position: { x: 250, y: 5 } },
+  { id: "2", data: { label: "Node 2" }, position: { x: 100, y: 100 } },
+  { id: "e1-2", source: "1", target: "2", animated: true },
+];
 
 // const elementsTypes = [
 //   {
@@ -45,7 +46,6 @@ const initialState = {
 };
 
 export default function Map(props) {
-  const [elements, setElements] = useState([]);
   const client = useApolloClient();
   const [open, setOpen] = useState(false);
   const [stateCoord, setStateCoord] = useState(initialState);
@@ -54,18 +54,13 @@ export default function Map(props) {
 
   //pass onChange function...onChange, find the corresponding vertex, set its label to event value
   //onChange thunk
-  const onChange = (id, elements) => (event) => {
-    const newElements = elements.map((ele) => {
-      return ele.id === id
-        ? { ...ele, data: { ...data, label: event.target.value } }
-        : ele;
-    });
-    setElements(newElements);
-  };
 
-  useEffect(() => {
-    setElements(parseVertices(props.vertexData, onChange));
-  }, []);
+  /* do local state management entirely with cache;
+  use query to query vertices
+  -> manipulation of vertices can be done when using query within onChange
+  -> Will the elements be automatically updated? In other words, are changes broadcasted from Mapcreator component to Map component?
+    - if yes: good
+    - if no: perhaps you want to change the business logic and situate the GET_GRAPH query within Map component */
 
   /* handlers for context menu */
   const handleClickMenu = (event) => {
@@ -97,7 +92,11 @@ export default function Map(props) {
 
   return (
     <div onContextMenu={handleClickMenu}>
-      <ReactFlow elements={props.data} style={graphStyles}>
+      <ReactFlow
+        elements={elements}
+        style={graphStyles}
+        nodeTypes={{ inputNode }}
+      >
         <Controls />
         <Background variant="dots" gap={12} size={1} />
       </ReactFlow>

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -9,11 +9,6 @@ import Typography from "@material-ui/core/Typography";
 import DialogForm from "../components/DialogForm";
 import { showMessage } from "../utils/appState";
 
-const CustomNodeFlow = () => {
-  const [elements, setElements] = useState([]);
-
-
-
 // const elements = [
 //   { id: "1", data: { label: "Node 1" }, position: { x: 250, y: 5 } },
 //   { id: "2", data: { label: "Node 2" }, position: { x: 100, y: 100 } },
@@ -55,10 +50,7 @@ export default function Map(props) {
   const [newNodeData, setNewNodeData] = useState("");
   const [newNodeCoord, setNewNodeCoord] = useState({ x: null, y: null });
 
-  //   useEffect(() => {
-  //     if (newNodeData !== "") {
-  //     }
-  //   }, [newNodeData, newNodeData, props.cre]);
+
 
   /* handlers for context menu */
   const handleClickMenu = (event) => {

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -8,6 +8,7 @@ import Typography from "@material-ui/core/Typography";
 
 import DialogForm from "../components/DialogForm";
 import { showMessage } from "../utils/appState";
+import { parseVertices } from "../utils";
 
 // const elements = [
 //   { id: "1", data: { label: "Node 1" }, position: { x: 250, y: 5 } },
@@ -44,13 +45,27 @@ const initialState = {
 };
 
 export default function Map(props) {
+  const [elements, setElements] = useState([]);
   const client = useApolloClient();
   const [open, setOpen] = useState(false);
   const [stateCoord, setStateCoord] = useState(initialState);
   const [newNodeData, setNewNodeData] = useState("");
   const [newNodeCoord, setNewNodeCoord] = useState({ x: null, y: null });
 
+  //pass onChange function...onChange, find the corresponding vertex, set its label to event value
+  //onChange thunk
+  const onChange = (id, elements) => (event) => {
+    const newElements = elements.map((ele) => {
+      return ele.id === id
+        ? { ...ele, data: { ...data, label: event.target.value } }
+        : ele;
+    });
+    setElements(newElements);
+  };
 
+  useEffect(() => {
+    setElements(parseVertices(props.vertexData, onChange));
+  }, []);
 
   /* handlers for context menu */
   const handleClickMenu = (event) => {

--- a/src/components/inputNode.js
+++ b/src/components/inputNode.js
@@ -15,7 +15,7 @@ export default memo(({ data }) => {
     <>
       <Handle
         type="target"
-        postion="left"
+        postion="bottom"
         style={{ background: "#fff" }}
         onConnect={(params) => console.log("handle onConnect", params)}
       />

--- a/src/components/inputNode.js
+++ b/src/components/inputNode.js
@@ -1,0 +1,44 @@
+import React, { memo } from "react";
+import { Handle } from "react-flow-renderer";
+import InputBase from "@material-ui/core/InputBase";
+import { makeStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme) => ({
+  margin: {
+    margin: theme.spacing(1),
+  },
+}));
+
+export default memo(({ data }) => {
+  const classes = useStyles();
+  return (
+    <>
+      <Handle
+        type="target"
+        postion="left"
+        style={{ background: "#fff" }}
+        onConnect={(params) => console.log("handle onConnect", params)}
+      />
+      <div>
+        <InputBase
+          className={classes.margin}
+          defaultValue={data.label}
+          onChange={data.onChange}
+          inputProps={{ "aria-label": "naked" }}
+        />
+        <Handle
+          type="source"
+          position="right"
+          id="a"
+          style={{ top: 10, background: "#fff" }}
+        />
+        <Handle
+          type="source"
+          position="right"
+          id="b"
+          style={{ bottom: 10, top: "auto", background: "#fff" }}
+        />
+      </div>
+    </>
+  );
+});

--- a/src/components/inputNode.js
+++ b/src/components/inputNode.js
@@ -1,30 +1,52 @@
-import React, { memo } from "react";
+import React, { memo, useState } from "react";
 import { Handle } from "react-flow-renderer";
 import InputBase from "@material-ui/core/InputBase";
 import { makeStyles } from "@material-ui/core/styles";
+import { useMutation } from "@apollo/react-hooks";
+import { UPDATE_VERTEX_LABEL } from "../cache/mutations";
 
 const useStyles = makeStyles((theme) => ({
   margin: {
     margin: theme.spacing(1),
   },
+  node: {
+    background: "rgba(142,142,142,0.5)",
+    border: "2px",
+    borderRadius: "5px",
+    padding: "5%",
+    boxShadow: "2px 2px 2px rgba(160,160,160,0.8)",
+  },
 }));
 
-export default memo(({ data }) => {
+export default memo(({ id, data }) => {
   const classes = useStyles();
+  const [updateLabel] = useMutation(UPDATE_VERTEX_LABEL);
+
+  const handleChange = (event) => {
+    updateLabel({
+      variables: { id, newLabel: event.target.value },
+    });
+  };
+
   return (
     <>
-      <Handle type="target" postion="top" style={{ background: "#fff" }} />
+      <Handle
+        type="target"
+        postion="top"
+        style={{ background: "rgba(120,120,120,0.5)" }}
+      />
       <div>
         <InputBase
-          className={classes.margin}
           value={data.label}
-          onChange={data.onChange}
-          inputProps={{ "aria-label": "naked" }}
+          onChange={handleChange}
+          inputProps={{ style: { textAlign: "center" } }}
+          multiline={true}
+          className={classes.node}
         />
         <Handle
           type="source"
           position="bottom"
-          style={{ background: "#fff" }}
+          style={{ background: "rgba(120,120,120,0.5)" }}
         />
       </div>
     </>

--- a/src/components/inputNode.js
+++ b/src/components/inputNode.js
@@ -22,6 +22,7 @@ export default memo(({ data }) => {
       <div>
         <InputBase
           className={classes.margin}
+          value={data.label}
           defaultValue={data.label}
           onChange={data.onChange}
           inputProps={{ "aria-label": "naked" }}

--- a/src/components/inputNode.js
+++ b/src/components/inputNode.js
@@ -13,12 +13,7 @@ export default memo(({ data }) => {
   const classes = useStyles();
   return (
     <>
-      <Handle
-        type="target"
-        postion="bottom"
-        style={{ background: "#fff" }}
-        onConnect={(params) => console.log("handle onConnect", params)}
-      />
+      <Handle type="target" postion="top" style={{ background: "#fff" }} />
       <div>
         <InputBase
           className={classes.margin}
@@ -29,15 +24,8 @@ export default memo(({ data }) => {
         />
         <Handle
           type="source"
-          position="right"
-          id="a"
-          style={{ top: 10, background: "#fff" }}
-        />
-        <Handle
-          type="source"
-          position="right"
-          id="b"
-          style={{ bottom: 10, top: "auto", background: "#fff" }}
+          position="bottom"
+          style={{ background: "#fff" }}
         />
       </div>
     </>

--- a/src/components/inputNode.js
+++ b/src/components/inputNode.js
@@ -18,7 +18,6 @@ export default memo(({ data }) => {
         <InputBase
           className={classes.margin}
           value={data.label}
-          defaultValue={data.label}
           onChange={data.onChange}
           inputProps={{ "aria-label": "naked" }}
         />

--- a/src/pages/MapCreator.js
+++ b/src/pages/MapCreator.js
@@ -20,24 +20,7 @@ export default function MapCreator() {
     },
   });
 
-  // {
-  //   update(
-  //     cache,
-  //     {
-  //       data: {
-  //         deleteGraph: {
-  //           graph: { id },
-  //         },
-  //       },
-  //     }
-  //   ) {
-  //     const { allGraphs } = cache.readQuery({ query: GET_GRAPHS });
-  //     cache.writeQuery({
-  //       query: GET_GRAPHS,
-  //       data: { allGraphs: allGraphs.filter((graph) => graph.id !== id) },
-  //     });
-  //   },
-  // }
+//just data.graph.vertices? check this, move logic into map
 
   const [createVertex, { data: createdVertex }] = useMutation(CREATE_VERTEX);
 

--- a/src/pages/MapCreator.js
+++ b/src/pages/MapCreator.js
@@ -15,12 +15,7 @@ export default function MapCreator() {
   //fetch graph
   const { data: graphData, loading, client } = useQuery(GET_GRAPH, {
     variables: { id: graphId },
-    onCompleted: (data) => {
-      setParsedData(parseVertices(data.graph.vertices));
-    },
   });
-
-//just data.graph.vertices? check this, move logic into map
 
   const [createVertex, { data: createdVertex }] = useMutation(CREATE_VERTEX);
 
@@ -35,7 +30,7 @@ export default function MapCreator() {
     <Loader open={loading} />
   ) : (
     <div>
-      <Map data={parsedData} createVertex={createVertex} />
+      <Map vertexData={graphData.graph.vertices} createVertex={createVertex} />
     </div>
   );
 }

--- a/src/pages/MapCreator.js
+++ b/src/pages/MapCreator.js
@@ -16,7 +16,6 @@ export default function MapCreator() {
   const { data: graphData, loading, client } = useQuery(GET_GRAPH, {
     variables: { id: graphId },
     onCompleted: (data) => {
-      console.log("data", data);
       setParsedData(parseVertices(data.graph.vertices));
     },
   });
@@ -53,7 +52,7 @@ export default function MapCreator() {
     <Loader open={loading} />
   ) : (
     <div>
-      <Map data={parsedData} createVertex={createVertex}/>
+      <Map data={parsedData} createVertex={createVertex} />
     </div>
   );
 }

--- a/src/pages/MapCreator.js
+++ b/src/pages/MapCreator.js
@@ -9,7 +9,6 @@ import Loader from "../components/Loader";
 import { parseVertices } from "../utils/index";
 
 export default function MapCreator() {
-  const [parsedData, setParsedData] = useState();
   const graphId = useParams().id;
 
   //fetch graph
@@ -30,7 +29,7 @@ export default function MapCreator() {
     <Loader open={loading} />
   ) : (
     <div>
-      <Map vertexData={graphData.graph.vertices} createVertex={createVertex} />
+      <Map graphData={graphData.graph} createVertex={createVertex} />
     </div>
   );
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,5 @@
 /* convert data into array for react flow renderer */
-export function parseVertices(vertices, edgeIsAnimated = true) {
+export function parseVertices(vertices, onChange, edgeIsAnimated = true) {
   let edges = [];
   // map over all the vertices in the graph
   const nodes = vertices.map((vertex) => {
@@ -21,7 +21,11 @@ export function parseVertices(vertices, edgeIsAnimated = true) {
     if (type === "default") {
       return { id: `${id}`, data: { label: `${data}` }, position: { x, y } };
     } else if (type === "inputNode") {
-      return { id: `${id}`, data: { label: `${data}` }, position: { x, y } };
+      return {
+        id: `${id}`,
+        data: { onChange: onChange(id), label: `${data}` },
+        position: { x, y },
+      };
     }
   });
   return edges.length === 0 ? [...nodes] : [...nodes, ...edges];

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,5 @@
 /* convert data into array for react flow renderer */
-export function parseVertices(vertices, onChange, edgeIsAnimated = true) {
+export function parseVertices(vertices, edgeIsAnimated = true) {
   let edges = [];
   // map over all the vertices in the graph
   const nodes = vertices.map((vertex) => {
@@ -24,7 +24,7 @@ export function parseVertices(vertices, onChange, edgeIsAnimated = true) {
       return {
         id: `${id}`,
         type,
-        data: { onChange: onChange(id), label: `${data}` },
+        data: { label: `${data}` },
         position: { x, y },
       };
     }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -23,6 +23,7 @@ export function parseVertices(vertices, onChange, edgeIsAnimated = true) {
     } else if (type === "inputNode") {
       return {
         id: `${id}`,
+        type,
         data: { onChange: onChange(id), label: `${data}` },
         position: { x, y },
       };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -3,7 +3,7 @@ export function parseVertices(vertices, edgeIsAnimated = true) {
   let edges = [];
   // map over all the vertices in the graph
   const nodes = vertices.map((vertex) => {
-    const { id, data, x, y, targets } = vertex;
+    const { id, data, type, x, y, targets } = vertex;
     // extract all targets of this vertex
     if (targets.length !== 0) {
       const vertexTargets = targets.map((target) => {
@@ -17,7 +17,12 @@ export function parseVertices(vertices, edgeIsAnimated = true) {
       // append targets of this vertex to edges
       edges = edges.concat(vertexTargets);
     }
-    return { id: `${id}`, data: { label: `${data}` }, position: { x, y } };
+    // return correct node type
+    if (type === "default") {
+      return { id: `${id}`, data: { label: `${data}` }, position: { x, y } };
+    } else if (type === "inputNode") {
+      return { id: `${id}`, data: { label: `${data}` }, position: { x, y } };
+    }
   });
   return edges.length === 0 ? [...nodes] : [...nodes, ...edges];
 }


### PR DESCRIPTION
## New data model

new data model allows to query a graph's vertices and edges in the same query; 
**vertices** and **edges** can be _passed directly to react flow_, parsing is no longer required

## Custom input type

* custom node input type enables user to edit node's text
  * uses MaterialsUI InputBase component
* local state management of node data is done with Apollo client
  * added local resolver **updateVertexLabel**
  * mutation hook is used in input node to update the node's text
