### PR TITLE
Update coordinates

### DIFF
--- a/src/cache/mutations.js
+++ b/src/cache/mutations.js
@@ -99,17 +99,16 @@ export const UPDATE_VERTEX_DATA = gql`
   }
 `;
 
-export const UPDATE_COORD = gql`
+export const UPDATE_POSITION = gql`
   mutation($id: ID!, $x: Int!, $y: Int!) {
-    createVertex(id: $id, x: $x, y: $y) {
+    updateVertexPosition(id: $id, position: { x: $x, y: $y }) {
       vertex {
         id
-        data
-        x
-        y
+        position {
+          x
+          y
+        }
       }
-      success
-      message
     }
   }
 `;

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -8,7 +8,11 @@ import MenuItem from "@material-ui/core/MenuItem";
 import inputNode from "./inputNode";
 import { showMessage } from "../utils/appState";
 import { GET_GRAPH } from "../cache/queries";
-import { CREATE_VERTEX, CREATE_EDGE } from "../cache/mutations";
+import {
+  CREATE_VERTEX,
+  CREATE_EDGE,
+  UPDATE_POSITION,
+} from "../cache/mutations";
 
 const graphStyles = { width: "100%", height: "93vh" };
 
@@ -61,6 +65,12 @@ export default function Map(props) {
       });
     },
   });
+
+  const [updatePosition] = useMutation(UPDATE_POSITION);
+  //callback for react flow renderer
+  const updateCoordinates = ({ id, position: { x, y } }) =>
+    updatePosition({ variables: { id, x, y } });
+
   //callback for react flow renderer
   const makeEdge = ({ source, target }) => {
     createEdge({ variables: { sourceId: source, targetId: target } });
@@ -99,6 +109,7 @@ export default function Map(props) {
         style={graphStyles}
         nodeTypes={{ inputNode }}
         onConnect={makeEdge}
+        onNodeDragStop={updateCoordinates}
       >
         <Controls />
         <Background variant="dots" gap={12} size={1} />


### PR DESCRIPTION
## Autosave coordinates of node after dragging

- _adapted updatePosition mutation_ to fit new data model; returns id and new data to trigger automatic cache update
- added useMutation hook to Map component
- wrote **callback updateCoordinates** which calls the mutate function with variables provided by React Flow
- pass _updateCoordinates_ to **React Flow's onNodeDragStop** prop